### PR TITLE
Add resetting feature, with push/pop-like functionality

### DIFF
--- a/gulp-env.d.ts
+++ b/gulp-env.d.ts
@@ -5,26 +5,35 @@ declare module "gulp-env" {
     [key: string]: any;
   }
 
+  interface ForceableStream extends NodeJS.ReadWriteStream {
+    force: boolean;
+  }
+
+  interface EnvStream extends NodeJS.ReadWriteStream {
+    reset: ForceableStream;
+    restore(force?: boolean): boolean;
+  }
+
   interface Env {
-    (file: string): NodeJS.ReadWriteStream;
+    (file: string): EnvStream;
 
     (options: {
       vars: EnvironmentMapping,
-    }): NodeJS.ReadWriteStream;
+    }): EnvStream;
 
     (options: {
       file: string,
       handler?: (contents: string) => EnvironmentMapping,
       vars?: EnvironmentMapping,
-    }): NodeJS.ReadWriteStream;
+    }): EnvStream;
 
     (options: {
       file: string,
       type: string,
       vars?: EnvironmentMapping,
-    }): NodeJS.ReadWriteStream;
+    }): EnvStream;
 
-    set(vars: EnvironmentMapping): NodeJS.ReadWriteStream;
+    set(vars: EnvironmentMapping): EnvStream;
   }
 
   export default Env;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-env",
-  "version": "0.3.0",
-  "description": "Add env vars from a .env file to your process.env",
+  "version": "0.4.0",
+  "description": "Add env vars to your process.env",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js"
@@ -18,8 +18,8 @@
     "gulpfriendly"
   ],
   "contributors": [
-    "Isiah Meadows <isiahmeadows@gmail.com> (https://github.com/impinball)",
-    "Moveline"
+    "Moveline",
+    "Isiah Meadows <isiahmeadows@gmail.com> (https://github.com/impinball)"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Adds the following APIs:

``` js
envs.restore() // synchronous restore
envs.restore(true) // same, but ignore conflicts

envs.reset // streamified (for Gulp) version of .restore(), called on stream flush
envs.reset.force // same, but ignore conflicts
```

Effectively allows for env push/pop, and easy resetting. Bumps the package version one minor version.
